### PR TITLE
enable ActiveRecord::Dirty API for fields

### DIFF
--- a/core/test/models/concerns/push_type/customizable_test.rb
+++ b/core/test/models/concerns/push_type/customizable_test.rb
@@ -29,5 +29,19 @@ module PushType
       it { page.attribute_for_inspect(:field_store).must_equal "[:foo, :bar, :baz, :qux]" }
     end
 
+    describe '#attribute_changed?' do
+      it { page.foo_changed?.must_equal false }
+      it { page.changes.key?(:foo).must_equal false }
+
+      it 'returns true when attribute is changed' do
+        page.foo = 'value'
+        page.foo_changed?.must_equal true
+      end
+
+      it 'returns true when attribute is changed' do
+        page.foo = 'value'
+        page.changes.key?(:foo).must_equal true
+      end
+    end
   end
 end


### PR DESCRIPTION
This change enables the ActiveModel::Dirty syntax that is to be expected for native ActiveRecord classes:

```
class Foo < PushType::Node
  field :bar
end

foo = Foo.new
foo.bar = "baz"
foo.bar_changed? #=> true
```

I was recently motivated by a rather complicated validation I needed recently where I needed to verify an audio file and wanted conditional validation and quickly realized that I didn't have it, but knew it was easy to piggyback onto Rails' built-in features:
```
field :audio_recording_url, :string
before_validation :inspect_metadata, :if => :audio_recording_url_changed?

def inspect_metadata
  # perform metadata inspection
end
```