### PR TITLE
Fix Fixnum warning on Ruby 2.4

### DIFF
--- a/core/lib/push_type/core_ext/to_bool.rb
+++ b/core/lib/push_type/core_ext/to_bool.rb
@@ -4,7 +4,7 @@ class String
   end
 end
 
-class Fixnum
+(defined?(Integer) ? Integer : Fixnum).class_eval do
   def to_bool
     !self.zero?
   end


### PR DESCRIPTION
Fixnum and Bignum have been combined into Integer

Fixes #35