### PR TITLE
Fix presenter loading

### DIFF
--- a/core/app/models/concerns/push_type/presentable.rb
+++ b/core/app/models/concerns/push_type/presentable.rb
@@ -17,10 +17,9 @@ module PushType
       end
 
       def presenter_class
-        unless Object.const_defined?(presenter_class_name)
-          Object.const_set presenter_class_name, Class.new(PushType::Presenter)
-        end
         Object.const_get presenter_class_name
+      rescue NameError
+        Object.const_set presenter_class_name, Class.new(PushType::Presenter)
       end
 
     end

--- a/core/lib/push_type/testing/common_rake.rb
+++ b/core/lib/push_type/testing/common_rake.rb
@@ -2,6 +2,7 @@ require 'generators/push_type/dummy/dummy_generator'
 require 'generators/push_type/install/install_generator'
 require 'generators/push_type/node/node_generator'
 require 'generators/push_type/structure/structure_generator'
+require 'generators/push_type/presenter/presenter_generator'
 
 namespace :common do
 
@@ -18,6 +19,7 @@ namespace :common do
       system 'bin/rails db:drop db:create'
       PushType::InstallGenerator.start ['--quiet']
       PushType::NodeGenerator.start ['page', '--quiet']
+      PushType::PresenterGenerator.start ['page', '--quiet']
       PushType::StructureGenerator.start ['location', '--quiet']
     end
   end

--- a/core/test/models/concerns/push_type/presentable_test.rb
+++ b/core/test/models/concerns/push_type/presentable_test.rb
@@ -21,5 +21,27 @@ module PushType
       it { page.location.present!.class.ancestors.must_include PushType::Presenter }
     end
 
+    it "autoloads the presenter" do
+      begin
+        ::PresentableNode = Class.new(PushType::Node)
+
+        file = "#{Rails.root}/app/presenters/presentable_node_presenter.rb"
+        File.write(file, <<-RUBY)
+        class PresentableNodePresenter < PushType::Presenter
+          def self.static?
+            true
+          end
+        end
+        RUBY
+
+        PresentableNode.presenter_class_name.must_equal "PresentableNodePresenter"
+        PresentableNode.presenter_class.static?.must_equal true
+      ensure
+        Object.send(:remove_const, :PresentableNode)
+        Object.send(:remove_const, :PresentableNodePresenter) if defined?(::PresentableNodePresenter)
+        FileUtils.rm_f(file)
+      end
+    end
+
   end
 end


### PR DESCRIPTION
In Rails' default test environment configuration, a presenter statically
specified in app/presenters/ would fail to be loaded by
PushType::Presentable. This is because the Object.const_defined? check
would return false, and so PushType would dynamically define its own
version of the presenter class, thus ignoring the presenter class
definition on disk.

This stems from the test environment configuration which has
cache_classes set to true and eager_load set to false.

With this configuration, Rails won't try to load the file from disk when
Object.const_defined? is called. (I'm not sure the exact reason for
this.)

In development mode, we have cache_classes and eager_load both set to
false. This works fine.

In production mode, we have eager_load set to true, which obviously
means that any presenters defined in app/presenters will be loaded
up-front when the application starts. So this also works fine.

Therefore, the problem is only noticeable in the test environment.

Note that I'm generating a PagePresenter in the dummy app, there are two
reasons for this:

1. It causes an app/presenters/ directory to get generated, which is
   needed to put the presenter in which is used in the test I've added
   (the directory must exist at application boot time, so that Rails adds
   it to the autoload_paths)

2. It adds surface area and diversity to the test suite by exercising the
   presenter generator too