### PR TITLE
Accept up to pg version 0.21

### DIFF
--- a/core/push_type_core.gemspec
+++ b/core/push_type_core.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.license       = 'MIT'
 
   s.add_dependency 'rails',         ['>= 5.0', '< 5.2']
-  s.add_dependency 'pg',            ['>= 0.18', '< 0.20']
+  s.add_dependency 'pg',            ['>= 0.18', '< 0.22']
   s.add_dependency 'closure_tree',  '~> 6.5.0'
   s.add_dependency 'dragonfly',     '~> 1.1.2'
   s.add_dependency 'redcarpet',     '~> 3.4.0'


### PR DESCRIPTION
Changed the core gemspec to allow up-to pg version 0.21 (less than 0.22).