### PR TITLE
Fix conflicts with apps using multiple engines

### DIFF
--- a/admin/lib/push_type/kaminari_patch.rb
+++ b/admin/lib/push_type/kaminari_patch.rb
@@ -2,12 +2,14 @@ module Kaminari
   module Helpers
     class Tag
 
+      alias :base_page_url_for :page_url_for
+
       def page_url_for(page)
         arguments = @params.merge(@param_name => (page <= 1 ? nil : page), only_path: true).symbolize_keys
         begin
           PushType::Admin::Engine.routes.url_helpers.url_for arguments
         rescue
-          @template.main_app.url_for arguments
+          base_page_url_for(page)
         end
       end
 


### PR DESCRIPTION
If routes are being pulled in via another Engine, the `map_app.url_for` can fail resulting in a `ActionController::UrlGenerationError` error