### PR TITLE
Added media url to "Edit Media" page.

### DIFF
--- a/admin/app/views/push_type/admin/assets/_form.html.haml
+++ b/admin/app/views/push_type/admin/assets/_form.html.haml
@@ -30,6 +30,11 @@
                   %tr
                     %th Content type
                     %td {{ asset.mime_type }}
+                  - if @asset.persisted?
+                    %tr
+                      %th URL
+                      %td
+                        = link_to media_url(@asset), media_url(@asset)
           .row.string
             .columns
               = f.label :description
@@ -41,4 +46,4 @@
           = render 'meta_table'
         .submit.text-center
           = render 'form_submit'
-              
+


### PR DESCRIPTION
Customers sometimes want to be able to link to the uploaded asset from other locations. This provides a direct link to the asset from the Media/Edit media page in the PushType admin. 