### PR TITLE
Pass CSRF token in asset upload request

### DIFF
--- a/admin/app/webpack/javascripts/directives/asset-upload.es6
+++ b/admin/app/webpack/javascripts/directives/asset-upload.es6
@@ -22,6 +22,9 @@ export default Vue.directive('asset-upload', {
         drop:         function() { $(this).removeClass('hover') },
         uploadFinished: function(i, file, response, time) {
           self.vm.afterUpload(response.asset);
+        },
+        data: {
+          authenticity_token: $('meta[name=csrf-token]').attr('content')
         }
       })
     } else {


### PR DESCRIPTION
This PR fixes #49. I faced the same issue with Rails 5.2 and push_type 0.12.1. Upon checking the parameters sent to `PushType::Admin::AssetsController#upload` I found that `authenticity_token` field was missing.
 
[https://discuss.pushtype.org/t/unprocessable-entity-upon-an-asset-upload/349](Forum thread)